### PR TITLE
Vektorius: Fix install instructions again

### DIFF
--- a/vektorius/README.md
+++ b/vektorius/README.md
@@ -1,7 +1,8 @@
 # Getting Started
+Vektorius is an Alpha product, and requires using the `edge` client. It is _highly_ recommended that you use a virtualenv when installing the `edge` client to ensure that you don't overwrite stable installations of the `descarteslabs` client with an `edge` client.
 
 ## Setting up a new virtualenv
-Vektorius is only available through the Alpha release of the client and can only be used with Python 3.6 or greater.  To get started you should create a new virtual environment:
+Vektorius is only available through the `edge` client and can only be used with Python 3.6 or greater.  To get started you should create a new virtual environment:
 
 ```
 git clone https://github.com/descarteslabs/tutorials.git
@@ -10,9 +11,6 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```
-
-And install the latest Alpha client, instructions are [here](https://docs.descarteslabs.com/installation.html#alpha-installation).
-
 
 Then run Jupyter with 
 
@@ -28,8 +26,10 @@ git clone https://github.com/descarteslabs/tutorials.git
 pip install -I -r tutorials/vektorius/requirements.txt
 ```
 
-And install the latest Alpha client, instructions are [here](https://docs.descarteslabs.com/installation.html#alpha-installation).
+Note that this will overwrite the default `descarteslabs` install with an `edge` client, so proceed with caution! You can revert these changes at any time with `pip install -I "descarteslabs[complete]"`.
 
-Note that this will overwrite the default `descarteslabs` install, so proceed with caution!
+## Updating the client
+
+You can update the latest version of the client with `pip install --upgrade -r requiments.txt`.
 
 

--- a/vektorius/README.md
+++ b/vektorius/README.md
@@ -28,6 +28,8 @@ git clone https://github.com/descarteslabs/tutorials.git
 pip install -I -r tutorials/vektorius/requirements.txt
 ```
 
+And install the latest Alpha client, instructions are [here](https://docs.descarteslabs.com/installation.html#alpha-installation).
+
 Note that this will overwrite the default `descarteslabs` install, so proceed with caution!
 
 

--- a/vektorius/requirements.txt
+++ b/vektorius/requirements.txt
@@ -1,1 +1,2 @@
+https://storage.googleapis.com/dl-workflows-pypi/edge/descarteslabs-internal.tar.gz
 jupyter==1.0.0


### PR DESCRIPTION
This simplifies the install instructions, and makes it a little clearer that Vektorius is an Alpha product, and using it requires an unstable `edge` client.